### PR TITLE
add allowParens option to no-confusing-arrow rule

### DIFF
--- a/common.js
+++ b/common.js
@@ -143,7 +143,10 @@ module.exports = {
       'off',
       'except-parens'
     ],
-    'no-confusing-arrow': 'warn',
+    'no-confusing-arrow': [
+      'warn',
+      { 'allowParens': true }
+    ],
     'no-continue': 'off',
     'no-console': 'warn',
     'no-const-assign': 'error',


### PR DESCRIPTION
It does not make sense to have [no-confusing-arrow](https://eslint.org/docs/rules/no-confusing-arrow) without `{'allowParens': true}` when used with [arrow-body-style](https://eslint.org/docs/rules/arrow-body-style). You're going to fall in an infinite loop of warnings.

E.g.
```
${props => props.isPrimary ? colorize('blue') : colorize('blue-pale')} // no-confusing-arrow warning
```

```
${props => {
    return props.isPrimary ? colorize('blue') : colorize('blue-pale'); // arrow-body-style error
}}
```
With `{'allowParens': true}`  on [no-confusing-arrow](https://eslint.org/docs/rules/no-confusing-arrow), you would fix writing in that way:
```
${props => (props.isPrimary ? colorize('blue') : colorize('blue-pale'))}
```